### PR TITLE
Implement RabbitMQ example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+plugins/
+data/
+

--- a/Dockerfile-postgres-beanstalk.alpine
+++ b/Dockerfile-postgres-beanstalk.alpine
@@ -1,16 +1,16 @@
 FROM fguillot/alpine-nginx-php7
 
-RUN cd /var/www \
-    && curl -sLO https://kanboard.net/kanboard-latest.zip \
-    && unzip -qq kanboard-latest.zip \
-    && rm -f *.zip \
-    && rm -rf app \
-    && mv /var/www/kanboard /var/www/app \
-    && chown -R nginx:nginx /var/www/app/data \
-    && chown -R nginx:nginx /var/www/app/plugins
+ENV KANBOARD_VERSION 1.0.46
+ENV KANBOARD_TARBALL https://github.com/kanboard/kanboard/archive/v${KANBOARD_VERSION}.tar.gz
 
-RUN cd /var/www/app && \
-    ./kanboard plugin:install https://github.com/kanboard/plugin-beanstalk/releases/download/v1.0.0/Beanstalk-1.0.0.zip
+RUN mkdir -p /var/www/app \
+  && curl -sLo - \
+  ${KANBOARD_TARBALL} | tar -xzf - --strip 1 -C /var/www/app
+
+WORKDIR /var/www/app
+RUN composer --prefer-dist --no-dev --optimize-autoloader install && \
+    chown -R nginx:nginx /var/www/app && \
+    ./cli plugin:install https://github.com/kanboard/plugin-beanstalk/releases/download/v1.0.0/Beanstalk-1.0.0.zip
 
 COPY files/kanboard/postgres_beanstalk.php /var/www/app/config.php
 COPY files/crontab/cronjob.alpine /var/spool/cron/crontabs/nginx

--- a/Dockerfile-postgres-rabbitmq.alpine
+++ b/Dockerfile-postgres-rabbitmq.alpine
@@ -1,0 +1,23 @@
+FROM fguillot/alpine-nginx-php7
+
+RUN apk update && \
+  apk add php7-bcmath && \
+  rm -rf /var/cache/apk/*
+
+ENV KANBOARD_VERSION 1.0.46
+ENV KANBOARD_TARBALL https://github.com/kanboard/kanboard/archive/v${KANBOARD_VERSION}.tar.gz
+
+RUN mkdir -p /var/www/app \
+  && curl -sLo - \
+  ${KANBOARD_TARBALL} | tar -xzf - --strip 1 -C /var/www/app
+
+WORKDIR /var/www/app
+RUN composer --prefer-dist --no-dev --optimize-autoloader install \
+  && chown -R nginx:nginx /var/www/app
+
+COPY files/crontab/cronjob.alpine /var/spool/cron/crontabs/nginx
+COPY files/services.d/cron /etc/services.d/cron
+COPY files/services.d/worker /etc/services.d/worker
+
+VOLUME /var/www/app/data
+VOLUME /var/www/app/plugins

--- a/compose.alpine.postgres.rabbitmq.yaml
+++ b/compose.alpine.postgres.rabbitmq.yaml
@@ -1,0 +1,34 @@
+version: '2'
+
+services:
+  database:
+    image: postgres:9.6-alpine
+    restart: always
+    environment:
+        POSTGRES_USER: kanboard
+        POSTGRES_PASSWORD: kanboard
+        POSTGRES_DB: kanboard
+    volumes:
+      - ./database:/var/lib/postgresql/data
+
+  rabbitmq:
+    hostname: rabbitmq
+    image: rabbitmq:3.6-alpine
+    restart: always
+    expose:
+      - "5672"
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile-postgres-rabbitmq.alpine
+    restart: always
+    volumes:
+      - ./data:/var/www/app/data
+      - ./plugins:/var/www/app/plugins
+      - ./files/kanboard/postgres-rabbitmq.php:/var/www/app/config.php
+    ports:
+      - "80"
+    depends_on:
+      - database
+      - rabbitmq

--- a/files/kanboard/postgres_rabbitmq.php
+++ b/files/kanboard/postgres_rabbitmq.php
@@ -1,0 +1,11 @@
+<?php
+
+define('ENABLE_URL_REWRITE', true);
+
+define('DB_DRIVER', 'postgres');
+define('DB_USERNAME', 'kanboard');
+define('DB_PASSWORD', 'kanboard');
+define('DB_HOSTNAME', 'database');
+define('DB_NAME', 'kanboard');
+
+define('RABBITMQ_HOSTNAME', 'rabbitmq');

--- a/files/services.d/worker/run
+++ b/files/services.d/worker/run
@@ -1,2 +1,2 @@
 #!/bin/execlineb -P
-s6-setuidgid nginx /var/www/app/kanboard worker
+s6-setuidgid nginx /var/www/app/cli worker


### PR DESCRIPTION
This Pull Request implements an example for using Kanboard with RabbitMQ. It is based on the experiences from fabricating #6 and inherits it. I am filing both Pull Requests to leave choice to the maintainer of these images.

Further it makes use of data volumes for the plugins directory, why it is detrimental to install the plugin by running

    docker-compose -f compose.alpine.postgres.rabbitmq.yaml run --rm --entrypoint /bin/bash app
    ./cli plugin:install https://github.com/kanboard/plugin-rabbitmq/releases/download/v1.0.0/RabbitMQ-1.0.0.zip

or similarily getting the Plugin into the `plugins/` directory.